### PR TITLE
feat: Add DesktopCapturer interface.

### DIFF
--- a/lib/src/desktop_capturer.dart
+++ b/lib/src/desktop_capturer.dart
@@ -1,0 +1,37 @@
+import 'dart:typed_data';
+
+enum SourceType {
+  kScreen,
+  kWindow,
+}
+
+class ThumbnailSize {
+  ThumbnailSize(this.width, this.height);
+  int width;
+  int height;
+}
+
+abstract class DesktopCapturerSource {
+  /// The identifier of a window or screen that can be used as a
+  /// chromeMediaSourceId constraint when calling
+  String get id;
+
+  /// A screen source will be named either Entire Screen or Screen <index>,
+  /// while the name of a window source will match the window title.
+  String get name;
+
+  ///A thumbnail image of the source. ARGB
+  ByteBuffer get thumbnail;
+
+  /// specified in the options passed to desktopCapturer.getSources.
+  /// The actual size depends on the scale of the screen or window.
+  ThumbnailSize get thumbnailSize;
+
+  /// The type of the source.
+  SourceType get type;
+}
+
+abstract class DesktopCapturer {
+  Future<List<DesktopCapturerSource>> getSources(
+      {List<SourceType> types, ThumbnailSize thumbnailSize});
+}

--- a/lib/src/desktop_capturer.dart
+++ b/lib/src/desktop_capturer.dart
@@ -5,10 +5,23 @@ enum SourceType {
   kWindow,
 }
 
+final desktopSourceTypeToString = <SourceType, String>{
+  SourceType.kScreen: 'screen',
+  SourceType.kWindow: 'window',
+};
+
+final tringToDesktopSourceType = <String, SourceType>{
+  'screen': SourceType.kScreen,
+  'window': SourceType.kWindow,
+};
+
 class ThumbnailSize {
   ThumbnailSize(this.width, this.height);
   int width;
   int height;
+  factory ThumbnailSize.fromMap(Map<dynamic, dynamic> map) {
+    return ThumbnailSize(map['width'], map['height']);
+  }
 }
 
 abstract class DesktopCapturerSource {
@@ -21,7 +34,7 @@ abstract class DesktopCapturerSource {
   String get name;
 
   ///A thumbnail image of the source. ARGB
-  ByteBuffer get thumbnail;
+  Uint8List? get thumbnail;
 
   /// specified in the options passed to desktopCapturer.getSources.
   /// The actual size depends on the scale of the screen or window.
@@ -33,5 +46,5 @@ abstract class DesktopCapturerSource {
 
 abstract class DesktopCapturer {
   Future<List<DesktopCapturerSource>> getSources(
-      {List<SourceType> types, ThumbnailSize thumbnailSize});
+      {required List<SourceType> types, ThumbnailSize? thumbnailSize});
 }

--- a/lib/src/desktop_capturer.dart
+++ b/lib/src/desktop_capturer.dart
@@ -17,11 +17,11 @@ final tringToDesktopSourceType = <String, SourceType>{
 
 class ThumbnailSize {
   ThumbnailSize(this.width, this.height);
-  int width;
-  int height;
   factory ThumbnailSize.fromMap(Map<dynamic, dynamic> map) {
     return ThumbnailSize(map['width'], map['height']);
   }
+  int width;
+  int height;
 }
 
 abstract class DesktopCapturerSource {

--- a/lib/src/media_stream.dart
+++ b/lib/src/media_stream.dart
@@ -53,7 +53,7 @@ abstract class MediaStream {
   }
 
   /// Clones the given [MediaStream] and all its tracks.
-  MediaStream clone();
+  Future<MediaStream> clone();
 
   Future<void> dispose() async {
     return Future.value();

--- a/lib/webrtc_interface.dart
+++ b/lib/webrtc_interface.dart
@@ -1,5 +1,6 @@
 library webrtc_interface;
 
+export 'src/desktop_capturer.dart';
 export 'src/enums.dart';
 export 'src/factory.dart';
 export 'src/media_recorder.dart';


### PR DESCRIPTION
Desktop capture interface, for macOS/Windows/Linux screen capture, supports Screen and Window enumeration, preview