### PR TITLE
Fix #883 in flutter_webrtc

### DIFF
--- a/lib/src/media_recorder.dart
+++ b/lib/src/media_recorder.dart
@@ -16,6 +16,7 @@ abstract class MediaRecorder {
     MediaStream stream, {
     Function(dynamic blob, bool isLastOne)? onDataChunk,
     String mimeType,
+    int timeSlice = 1000,
   });
 
   Future<dynamic> stop();


### PR DESCRIPTION
Issue Mentioned : https://github.com/flutter-webrtc/flutter-webrtc/issues/883

Changes - Now there is a timeslice argument in startWeb Function of MediaRecorder, which also resolves the problem of onDataChunk Method not triggering unless we stop the recording.