### PR TITLE
Add `addStreams` to `RTCRtpSender`

### DIFF
--- a/lib/src/rtc_rtp_sender.dart
+++ b/lib/src/rtc_rtp_sender.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'media_stream.dart';
 import 'media_stream_track.dart';
 import 'rtc_dtmf_sender.dart';
 import 'rtc_rtp_parameters.dart';
@@ -15,6 +16,8 @@ abstract class RTCRtpSender {
   Future<void> setTrack(MediaStreamTrack? track, {bool takeOwnership = true});
 
   Future<List<StatsReport>> getStats();
+
+  Future<void> setStreams(List<MediaStream> streams);
 
   RTCRtpParameters get parameters;
 


### PR DESCRIPTION
In order to have transceiver-only usage in RTC sessions, RTCRtpSender must be able to have streams set as per https://blog.mozilla.org/webrtc/rtcrtptransceiver-explored/

This PR enriches the Flutter API `RTCRtpSender` with the method `addStreams`