### PR TITLE
Update media_stream_track.dart

### DIFF
--- a/lib/src/media_stream_track.dart
+++ b/lib/src/media_stream_track.dart
@@ -92,6 +92,10 @@ abstract class MediaStreamTrack {
     throw UnimplementedError();
   }
 
+  void selectAudioOutput(String deviceId) {
+    throw UnimplementedError();
+  }
+
   Future<ByteBuffer> captureFrame() {
     throw UnimplementedError();
   }


### PR DESCRIPTION
Select Audio Output method created to be able to override it in flutter_webrtc, thus controlling which peripheral device is used