### PR TITLE
fix: make optional cname in RTCRTCPParameters nullable

### DIFF
--- a/lib/src/rtc_rtcp_parameters.dart
+++ b/lib/src/rtc_rtcp_parameters.dart
@@ -5,7 +5,7 @@ class RTCRTCPParameters {
   }
 
   /// The Canonical Name used by RTCP
-  String cname;
+  String? cname;
 
   /// Whether reduced size RTCP is configured or compound RTCP
   bool reducedSize;


### PR DESCRIPTION
It's hard to find documentation for this, but at least in Safari 15, cname is not defined.

This causes a livekit application compiled to web to crash [here](https://github.com/livekit/client-sdk-flutter/blob/v2.2.5/lib/src/track/local/video.dart#L496) when converting the JS object to dart