### PR TITLE
feat: expose rtc video value

### DIFF
--- a/lib/src/rtc_video_renderer.dart
+++ b/lib/src/rtc_video_renderer.dart
@@ -54,6 +54,8 @@ abstract class VideoRenderer {
 
   int get videoHeight;
 
+  RTCVideoValue get videoValue;
+
   bool get muted;
   set muted(bool mute);
 


### PR DESCRIPTION
It looks like the video track is sometimes rotated internally. Without access to rotation or the computed aspectRatio, it's difficult to know the actual size of the video